### PR TITLE
SuitSorter API

### DIFF
--- a/SuitSorter.cs
+++ b/SuitSorter.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using BepInEx.Logging;
+using UnityEngine.SceneManagement;
+
+namespace MoreSuits
+{
+    public abstract class SuitSorter
+    {
+        private static SuitSorter currentSorter;
+
+        public static SuitSorter CurrentSorter
+        {
+            get => currentSorter;
+            set
+            {
+                if(!IsSorterRegistered(value)) return;
+                bool isGameScene = SceneManager.GetActiveScene().name == "SampleSceneRelay";
+                SuitSorter previousSorter = currentSorter;
+                currentSorter = value;
+                if(previousSorter != null)
+                {
+                    try { previousSorter.SwitchedAwayFromSorter(isGameScene); }
+                    catch (Exception e) { previousSorter.Logger.LogError(e); }
+                }
+                try{currentSorter.SwitchedToSorter(isGameScene);}
+                catch(Exception e){currentSorter.Logger.LogError(e);}
+            }
+        }
+
+        public bool IsCurrentSorter => CurrentSorter == this;
+        public SuitLogger Logger { get; internal set; }
+
+        internal static ManualLogSource rootLogger;
+        internal static readonly Dictionary<string, SuitSorter> PossibleSorters = new Dictionary<string, SuitSorter>();
+
+        public static bool IsSorterRegistered(string identifier) => PossibleSorters.ContainsKey(identifier);
+        public static bool IsSorterRegistered(SuitSorter suitSorter) => PossibleSorters.ContainsValue(suitSorter);
+
+        public static void RegisterSorter(string identifier, SuitSorter suitSorter, bool ignoreConfigCheck = false)
+        {
+            if(PossibleSorters.ContainsKey(identifier)) return;
+            PossibleSorters.Add(identifier, suitSorter);
+            suitSorter.Logger = new SuitLogger(identifier, rootLogger);
+            try{suitSorter.OnRegistered();}catch(Exception e){ suitSorter.Logger.LogError(e); }
+            if(ignoreConfigCheck) return;
+            if (MoreSuitsMod.SelectedSorter == identifier)
+                CurrentSorter = suitSorter;
+        }
+
+        public static void DeregisterSorter(string identifier)
+        {
+            if(!PossibleSorters.ContainsKey(identifier)) return;
+            SuitSorter suitSorter = PossibleSorters[identifier];
+            if (suitSorter == CurrentSorter)
+                CurrentSorter = MoreSuitsMod._none;
+            try{suitSorter.OnDeregistered();}catch(Exception e){ suitSorter.Logger.LogError(e); }
+        }
+
+        public static bool TryGetSorterByIdentifier(string identifier, out SuitSorter suitSorter) =>
+            PossibleSorters.TryGetValue(identifier, out suitSorter);
+
+        public static void PatchedPositionSuits(StartOfRound startOfRound) =>
+            MoreSuitsMod.StartOfRoundPatch.PositionSuitsOnRackPatch(ref startOfRound);
+
+        public virtual void OnRegistered(){}
+        public virtual void SwitchedToSorter(bool isGameScene){}
+        public virtual void SwitchedAwayFromSorter(bool isGameScene){}
+        public virtual void OnGameSceneLoaded(StartOfRound startOfRound){}
+        public virtual void SortSuitRack(StartOfRound startOfRound, UnlockableSuit[] suits){}
+        public virtual void OnDeregistered(){}
+    }
+
+    public class SuitLogger
+    {
+        private string suitSorterId;
+        private ManualLogSource rootLogger;
+
+        internal SuitLogger(string identifier, ManualLogSource rootLogger)
+        {
+            suitSorterId = identifier;
+            this.rootLogger = rootLogger;
+        }
+
+        public void Log(LogLevel level, object data) => rootLogger.Log(level, $"[{suitSorterId}] {data}");
+        public void LogFatal(object data) => rootLogger.Log(LogLevel.Fatal, $"[{suitSorterId}] {data}");
+        public void LogError(object data) => rootLogger.Log(LogLevel.Error, $"[{suitSorterId}] {data}");
+        public void LogWarning(object data) => rootLogger.Log(LogLevel.Warning, $"[{suitSorterId}] {data}");
+        public void LogMessage(object data) => rootLogger.Log(LogLevel.Message, $"[{suitSorterId}] {data}");
+        public void LogInfo(object data) => rootLogger.Log(LogLevel.Info, $"[{suitSorterId}] {data}");
+        public void LogDebug(object data) => rootLogger.Log(LogLevel.Debug, $"[{suitSorterId}] {data}");
+    }
+}

--- a/SuitSorters/None.cs
+++ b/SuitSorters/None.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using UnityEngine;
+
+namespace MoreSuits.SuitSorters
+{
+    public class None : SuitSorter
+    {
+        public override void SortSuitRack(StartOfRound startOfRound, UnlockableSuit[] suits)
+        {
+            int index = 0;
+            foreach (UnlockableSuit suit in suits)
+            {
+                AutoParentToShip component = suit.gameObject.GetComponent<AutoParentToShip>();
+                component.overrideOffset = true;
+
+                float offsetModifier = 0.18f;
+                if (MoreSuitsMod.MakeSuitsFitOnRack && suits.Length > MoreSuitsMod.SUITS_PER_RACK)
+                {
+                    offsetModifier = offsetModifier / (Math.Min(suits.Length, 20) / 12f); // squish the suits together to make them all fit
+                }
+
+                component.positionOffset = new Vector3(-2.45f, 2.75f, -8.41f) + startOfRound.rightmostSuitPosition.forward * offsetModifier * (float)index;
+                component.rotationOffset = new Vector3(0f, 90f, 0f);
+
+                index++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Abstract

An API for developers to allow them to sort suits optimally. This implementation lays on top of the mod itself, allowing it to be safe. In the scenario of a SuitSorter/plugin being broken (for whatever reason), it will not effect the main mod itself. The API supports both loading by config or swapping at runtime (even in the middle of a round); however, the runtime feature is up to a mod to implement and use.

# How to Implement

[Create a BepInEx plugin as per usual](https://docs.bepinex.dev/articles/dev_guide/plugin_tutorial/index.html), but also add the following attribute,

```cs
[BepInDependency("x753.More_Suits")]
```

to get something like this

```cs
[BepInPlugin(MOD_GUID, MOD_NAME, MOD_VERSION)]
[BepInDependency("x753.More_Suits")]
class SuitSorterPlugin : BaseUnityPlugin
{
    internal const string MOD_GUID = "com.example.suitsorterplugin";
    internal const string MOD_NAME = "SuitSorterPlugin";
    internal const string MOD_VERSION = "1.0.0";
}
```

Now, create a new class and implement the `SuitSorter` abstract class.

```cs
internal class MySorter : SuitSorter
{
    // follow API docs...
}
```

Finally, on `Awake` (or really whenever), register an instance of the sorter

```cs
[BepInPlugin(MOD_GUID, MOD_NAME, MOD_VERSION)]
[BepInDependency("x753.More_Suits")]
class SuitSorterPlugin : BaseUnityPlugin
{
    internal const string MOD_GUID = "com.example.suitsorterplugin";
    internal const string MOD_NAME = "SuitSorterPlugin";
    internal const string MOD_VERSION = "1.0.0";

    public void Awake() => SuitSorter.RegisterSorter("mySorter", new MySorter())
}
```

Then, the SuitSorter API will handle everything from there. You don't even have to check if the config matches!

# Why?

From #26 , the reason being denied

> I think people are going to want to manage suits in a number of different ways, whether it be through the terminal or rack itself, and with how many mods depend on this for loading suits I think it would be best to keep it simple in scope, avoiding any updates that might result in increased maintenance or bloat.

And

> I have no plans on adding pages to this mod by itself. I recommend you split it off into its own mod...

But splitting off into your own mod is difficult when the mod itself depends entirely on Harmony patches, ***while*** staying optimized. This API allows developers to implement their own APIs that are optimized *and* give MoreSuits full control, while preventing game breaking errors from sorting errors.

# How the API was Designed

Extending on the previous paragraph, this API was designed to be *update safe*, meaning that if an individual plugin breaks, it will not effect the flow of the mod itself. Removing the problematic plugin will fix the original (so long as the original is not broken itself) and allow the user to continue using More Suits. While the implementation can be extended to detect if a SuitSorter is problematic, this system was not implemented in this PR; however, there is room for this feature.

As well as being safe, this implementation is also runtime-safe, meaning that sorters can be swapped *without* restarting **regardless of if a round is started or not**. Here is a demonstration of this with my [demo plugin](https://github.com/200Tigersbloxed/MoreSuitsPages) **(separate from the code)**.

![vhjbdgfhbjhbjd](https://github.com/x753/Lethal-Company-More-Suits/assets/45884377/7e827682-4c15-4897-ba84-49d856f9af1b)

# Conclusion

This PR redesigned to allow for developers to implement their own methods of sorting suits optimally while making sure that the main mod itself is not effected in the process. This method addresses the reasons for why #26 was rejected and provides an adequate solution for the reasons. If there are any questions or concerns, please reach out or comment and I will be happy to answer any and fix any issues!

<details>
<summary>API Documentation</summary>
<br>

## Static Properties

### CurrentSorter

`SuitSorter`

The currently used SuitSorter. This can be safely set by any mod to switch the sorting method. If a re-sort is needed it is up to each mod to implement that itself.

## Static Methods

### IsSorterRegistered

`bool`

`string identifier`

Returns true if a SuitSorter was registered by its identifier

### IsSorterRegistered

`bool`

`SuitSorter suitSorter`

Returns true if a SuitSorter was registered by its instance

### RegisterSuitSorter

`void`

`string identifier`, `SuitSorter suitSorter`, `bool ignoreConfigCheck = false`

Registers an instance of a SuitSorter to a specific identifier. `ignoreConfigCheck` will skip setting the CurrentSorter if the config's SelectedSorter matches the identifier.

### DeregisterSorter

`void`

`string identifier`

Removes a registered sorter by identifier.

### TryGetSorterByIdentifier

`bool`

`string identifier`, `out SuitSorter suitSorter`

Attempts to out a SuitSorter based on identifier. Returns false if there is no existing SuitSorter

### PatchedPositionSuits

`void`

`StartOfRound startOfRound`

Invokes the patched [`PositionSuitsOnRackPatch`](https://github.com/200Tigersbloxed/Lethal-Company-More-Suits/blob/main/MoreSuits.cs#L315). Helpful tool for re-sorting.

## Properties

### IsCurrentSorter

`bool`

Returns true if the instance is the current sorting method

### Logger

`SuitLogger` (readonly)

The `SuitLogger` class for the `SuitSorter`.

## Methods

### OnRegistered

`void`

Invoked whenever a SuitSorter is registered

### SwitchedToSorter (Current Only)

`void`

`bool isGameScene`

Invoked whenever a SuitSorter is set as the CurrentSorter

### SwitchedAwayFromSorter

`void`

`bool isGameScene`

Invoked whenever a SuitSorter that was the CurrentSorter, is no longer the CurrentSorter

### OnGameSceneLoaded (Current Only)

`void`

`StartOfRound startOfRound`

Invoked when the game scene is loaded

### SortSuitRack (Current Only)

`void`

`StartOfRound startOfRound`, `UnlockableSuit[] suits`

Invoked whenever the suits are to be sorted.

### OnDeregistered

`void`

Invoked whenever a SuitSorter is Deregistered
</details>

# Links

+ [Example Plugin Implementing the API](https://github.com/200Tigersbloxed/MoreSuitsPages)